### PR TITLE
Remove letstune.ModelParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- `letstune.ModelParams` has `model_cls` instead of a generic parameter.
 - Trainers now have parameters class set through `params_cls` instead of a generic parameter.
 - `letstune.keras.KerasTrainer` calls `model.fit` with turned off Keras logging (`verbose=0`). 
 
 ### Removed
+- Remove `letstune.ModelParams`. Instead, use `letstune.Params` with `model_cls` parameter.
 - Remove custom Keras and Scikit-Learn trainers. Basic trainers realize the same functionality in a more clear way.
 - Remove `letstune.Metric` class. Replace it with `str`. Now metrics are always greater-is-better.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- `letstune.ModelParams` has `model_cls` instead of a generic parameter.
 - Trainers now have parameters class set through `params_cls` instead of a generic parameter.
 - `letstune.keras.KerasTrainer` calls `model.fit` with turned off Keras logging (`verbose=0`). 
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ First, define your **parameters**:
 
 ```python
 import letstune
-from letstune import rand
+from letstune import Params, rand
 
-class SGDClassifierParams(letstune.Params):
+class SGDClassifierParams(Params):
     model_cls = SGDClassifier
 
     average: bool

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ First, define your **parameters**:
 import letstune
 from letstune import rand
 
-class SGDClassifierParams(letstune.ModelParams[SGDClassifier]):
+class SGDClassifierParams(letstune.Params):
+    model_cls = SGDClassifier
+
     average: bool
     l1_ratio: float = rand.uniform(0, 1)
     alpha: float = rand.uniform(1e-2, 1e0, log=True)

--- a/docs/source/params.rst
+++ b/docs/source/params.rst
@@ -10,13 +10,6 @@ Params class
    :members:
    :undoc-members:
 
-ModelParams class
-<<<<<<<<<<<<<<<<<
-
-.. autoclass:: letstune.ModelParams
-   :members:
-   :show-inheritance:
-
 Exceptions
 <<<<<<<<<<
 

--- a/examples/keras/advanced_mnist_epochtrainer.py
+++ b/examples/keras/advanced_mnist_epochtrainer.py
@@ -18,28 +18,28 @@ from tensorflow import keras
 from tensorflow.keras import layers
 
 import letstune
-from letstune import rand
+from letstune import Params, rand
 
 
-class DenseParams(letstune.Params):
+class DenseParams(Params):
     model_cls = layers.Dense
 
     units: int = rand.oneof(range(32, 512 + 1, 32))  # type: ignore
     activation: str = rand.oneof(["relu", "tanh"])  # type: ignore
 
 
-class AdamParams(letstune.Params):
+class AdamParams(Params):
     model_cls = keras.optimizers.Adam
 
     learning_rate: float = rand.uniform(1e-4, 1e-2, log=True)  # type: ignore
     epsilon: float = rand.uniform(1e-8, 1e1, log=True)  # type: ignore
 
 
-class AdadeltaParams(letstune.Params):
+class AdadeltaParams(Params):
     model_cls = keras.optimizers.Adadelta
 
 
-class MNISTParams(letstune.Params):
+class MNISTParams(Params):
     dense: DenseParams
     optimizer: AdamParams | AdadeltaParams
     dropout: bool

--- a/examples/keras/advanced_mnist_epochtrainer.py
+++ b/examples/keras/advanced_mnist_epochtrainer.py
@@ -22,17 +22,21 @@ from letstune import rand
 
 
 class DenseParams(letstune.ModelParams[layers.Dense]):
+    model_cls = layers.Dense
+
     units: int = rand.oneof(range(32, 512 + 1, 32))  # type: ignore
     activation: str = rand.oneof(["relu", "tanh"])  # type: ignore
 
 
 class AdamParams(letstune.ModelParams[keras.optimizers.Adam]):
+    model_cls = keras.optimizers.Adam
+
     learning_rate: float = rand.uniform(1e-4, 1e-2, log=True)  # type: ignore
     epsilon: float = rand.uniform(1e-8, 1e1, log=True)  # type: ignore
 
 
 class AdadeltaParams(letstune.ModelParams[keras.optimizers.Adadelta]):
-    pass
+    model_cls = keras.optimizers.Adadelta
 
 
 class MNISTParams(letstune.Params):

--- a/examples/keras/advanced_mnist_epochtrainer.py
+++ b/examples/keras/advanced_mnist_epochtrainer.py
@@ -21,21 +21,21 @@ import letstune
 from letstune import rand
 
 
-class DenseParams(letstune.ModelParams[layers.Dense]):
+class DenseParams(letstune.Params):
     model_cls = layers.Dense
 
     units: int = rand.oneof(range(32, 512 + 1, 32))  # type: ignore
     activation: str = rand.oneof(["relu", "tanh"])  # type: ignore
 
 
-class AdamParams(letstune.ModelParams[keras.optimizers.Adam]):
+class AdamParams(letstune.Params):
     model_cls = keras.optimizers.Adam
 
     learning_rate: float = rand.uniform(1e-4, 1e-2, log=True)  # type: ignore
     epsilon: float = rand.uniform(1e-8, 1e1, log=True)  # type: ignore
 
 
-class AdadeltaParams(letstune.ModelParams[keras.optimizers.Adadelta]):
+class AdadeltaParams(letstune.Params):
     model_cls = keras.optimizers.Adadelta
 
 

--- a/examples/keras/simple_mnist_epochtrainer.py
+++ b/examples/keras/simple_mnist_epochtrainer.py
@@ -16,10 +16,10 @@ from tensorflow import keras
 from tensorflow.keras import layers
 
 import letstune
-from letstune import rand
+from letstune import Params, rand
 
 
-class MNISTParams(letstune.Params):
+class MNISTParams(Params):
     units: int = rand.oneof(range(32, 512 + 1, 32))  # type: ignore
 
     def create_model(self) -> keras.Model:

--- a/examples/sklearn/digits_sgd_simpletrainer.py
+++ b/examples/sklearn/digits_sgd_simpletrainer.py
@@ -20,7 +20,7 @@ X_train, X_test, y_train, y_test = train_test_split(
 )
 
 
-class SGDClassifierParams(letstune.ModelParams[SGDClassifier]):
+class SGDClassifierParams(letstune.Params):
     model_cls = SGDClassifier
 
     average: bool

--- a/examples/sklearn/digits_sgd_simpletrainer.py
+++ b/examples/sklearn/digits_sgd_simpletrainer.py
@@ -21,6 +21,8 @@ X_train, X_test, y_train, y_test = train_test_split(
 
 
 class SGDClassifierParams(letstune.ModelParams[SGDClassifier]):
+    model_cls = SGDClassifier
+
     average: bool
     l1_ratio: float = rand.uniform(0, 1)  # type: ignore
     alpha: float = rand.uniform(1e-2, 1e0, log=True)  # type: ignore
@@ -54,6 +56,7 @@ tuning = letstune.tune(
     16,
     dataset=(X_train, X_test, y_train, y_test),
     results_dir=Path.home() / "ltexamples/digits_sgd_simpletrainer",
+    passthrough_errors=True,
 )
 print(f" DONE: {tuning}")
 

--- a/examples/sklearn/digits_sgd_simpletrainer.py
+++ b/examples/sklearn/digits_sgd_simpletrainer.py
@@ -10,7 +10,7 @@ from sklearn.linear_model import SGDClassifier
 from sklearn.model_selection import train_test_split
 
 import letstune
-from letstune import rand
+from letstune import Params, rand
 from letstune.trainer import MetricValues
 
 X, y = sklearn.datasets.load_digits(return_X_y=True)
@@ -20,7 +20,7 @@ X_train, X_test, y_train, y_test = train_test_split(
 )
 
 
-class SGDClassifierParams(letstune.Params):
+class SGDClassifierParams(Params):
     model_cls = SGDClassifier
 
     average: bool

--- a/examples/sklearn/digits_sgd_simpletrainer_cv.py
+++ b/examples/sklearn/digits_sgd_simpletrainer_cv.py
@@ -22,7 +22,7 @@ X_train, X_test, y_train, y_test = train_test_split(
 )
 
 
-class SGDClassifierParams(letstune.ModelParams[SGDClassifier]):
+class SGDClassifierParams(letstune.Params):
     model_cls = SGDClassifier
 
     average: bool

--- a/examples/sklearn/digits_sgd_simpletrainer_cv.py
+++ b/examples/sklearn/digits_sgd_simpletrainer_cv.py
@@ -23,6 +23,8 @@ X_train, X_test, y_train, y_test = train_test_split(
 
 
 class SGDClassifierParams(letstune.ModelParams[SGDClassifier]):
+    model_cls = SGDClassifier
+
     average: bool
     l1_ratio: float = rand.uniform(0, 1)  # type: ignore
     alpha: float = rand.uniform(1e-2, 1e0, log=True)  # type: ignore

--- a/examples/sklearn/digits_sgd_simpletrainer_cv.py
+++ b/examples/sklearn/digits_sgd_simpletrainer_cv.py
@@ -12,7 +12,7 @@ from sklearn.linear_model import SGDClassifier
 from sklearn.model_selection import cross_val_score, train_test_split
 
 import letstune
-from letstune import rand
+from letstune import Params, rand
 from letstune.trainer import MetricValues
 
 X, y = sklearn.datasets.load_digits(return_X_y=True)
@@ -22,7 +22,7 @@ X_train, X_test, y_train, y_test = train_test_split(
 )
 
 
-class SGDClassifierParams(letstune.Params):
+class SGDClassifierParams(Params):
     model_cls = SGDClassifier
 
     average: bool

--- a/examples/xgboost/classification_epochtrainer.py
+++ b/examples/xgboost/classification_epochtrainer.py
@@ -7,12 +7,12 @@ import xgboost as xgb
 from sklearn.datasets import make_classification
 
 import letstune
-from letstune import rand
+from letstune import Params, rand
 
 NUM_CLASSES = 3
 
 
-class BoosterParams(letstune.Params):
+class BoosterParams(Params):
     max_depth: int = rand.ints(2, 6)  # type: ignore
     eta: float = rand.uniform(0.01, 0.2, log=True)  # type: ignore
 

--- a/letstune/__init__.py
+++ b/letstune/__init__.py
@@ -1,7 +1,6 @@
 __all__ = [
     "__version__",
     "Params",
-    "ModelParams",
     "SimpleTrainer",
     "EpochTrainer",
     "tune",
@@ -10,7 +9,7 @@ __all__ = [
 __version__ = "0.3.0-dev"
 
 
-from .params import ModelParams, Params
+from .params import Params
 from .trainer import EpochTrainer, SimpleTrainer
 
 from .backend.facade import tune  # isort:skip

--- a/letstune/params.py
+++ b/letstune/params.py
@@ -135,13 +135,7 @@ def _validate_leftover_generators(dct: dict[str, Any]) -> None:
 
 
 def _assert_bases_are_valid(bases: tuple[Any, ...]) -> None:
-    valid = len(bases) == 1
-
-    if valid:
-        base = bases[0]
-        valid = base == Params
-
-    if not valid:
+    if bases != (Params,):
         raise TypeError(f"only letstune.Params is allowed as a base (got {bases})")
 
 

--- a/letstune/params.py
+++ b/letstune/params.py
@@ -1,18 +1,15 @@
-"""Base classes :class:`Params` and :class:`ModelParams`
-used to define hyper-parameters."""
+"""Base class :class:`Params` used to define hyper-parameters."""
 
 
 __all__ = [
     "Params",
-    "ModelParams",
     "NoDefaultRandomGeneratorError",
 ]
 
 import dataclasses
 import sys
-import typing
 from types import UnionType
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, final
+from typing import TYPE_CHECKING, Any, TypeVar, final
 
 import numpy as np
 
@@ -113,9 +110,7 @@ def _pop_field(
     return (field_name, field_type, dataclasses.field(metadata=metadata))
 
 
-def _validate_forbidden_methods(
-    name: str, dct: dict[str, Any], model_params: bool
-) -> None:
+def _validate_forbidden_methods(dct: dict[str, Any]) -> None:
     for k in dct:
         if k in {
             "__init__",
@@ -131,13 +126,6 @@ def _validate_forbidden_methods(
             "__setstate__",
         }:
             raise TypeError(f"cannot override {k}")
-        elif model_params and k == "create_model":
-            raise TypeError(
-                f"""cannot override create_model. """
-                f"""Please use letstune.Params as the base:\n"""
-                f"""class {name}(letstune.Params):\n"""
-                f"""    ...\n"""
-            )
 
 
 def _validate_leftover_generators(dct: dict[str, Any]) -> None:
@@ -151,27 +139,21 @@ def _assert_bases_are_valid(bases: tuple[Any, ...]) -> None:
 
     if valid:
         base = bases[0]
-        valid = base == Params or base == ModelParams
+        valid = base == Params
 
     if not valid:
-        raise TypeError(
-            f"only letstune.Params and letstune.ModelParams "
-            f"are allowed as a base (got {bases})"
-        )
+        raise TypeError(f"only letstune.Params is allowed as a base (got {bases})")
 
 
-def _is_class_from_letstune(name: str, dct: dict[str, Any]) -> bool:
-    return dct["__module__"] == "letstune.params" and name in {
-        "Params",
-        "ModelParams",
-    }
+def _is_class_letstune_params(name: str, dct: dict[str, Any]) -> bool:
+    return dct["__module__"] == "letstune.params" and name == "Params"
 
 
 class _ParamsMeta(type):
     def __new__(
         mcs: type, name: str, bases: tuple[Any, ...], dct: dict[str, Any]
     ) -> Any:
-        if _is_class_from_letstune(name, dct):
+        if _is_class_letstune_params(name, dct):
             return super().__new__(mcs, name, bases, dct)  # type: ignore
 
         _assert_bases_are_valid(bases)
@@ -179,7 +161,7 @@ class _ParamsMeta(type):
             dct,
             _pop_annotations(dct),
         )
-        _validate_forbidden_methods(name, dct, bases[0] == ModelParams)
+        _validate_forbidden_methods(dct)
 
         fields = [
             _pop_field(dct, field_name, field_type)
@@ -533,107 +515,20 @@ class Params(metaclass=_ParamsMeta):
         """  # noqa
         return {f.name: getattr(self, f.name) for f in dataclasses.fields(self)}
 
+    # trick to make mypy happy with custom overloads
+    create_model: Any  # type: ignore
 
-M = TypeVar("M")
-
-
-class ModelParams(Generic[M], Params):
-    """Base class used to define hyper-parameters, which are used
-    to create a model.
-
-    Has all features of the :class:`Params` class.
-
-    Additionally, it provides :meth:`create_model` method, which creates
-    the model using given params.
-
-    >>> class RandomForestRegressor:
-    ...     '''sklearn-like model class.'''
-    ...     def __init__(
-    ...         self,
-    ...         n_estimators: int = 100,
-    ...         min_samples_split: int = 2,
-    ...         max_features: str = "auto",
-    ...     ):
-    ...         self.n_estimators = n_estimators
-    ...         self.min_samples_split = min_samples_split
-    ...         self.max_features = max_features
-    ...
-    ...     def fit(self, X, y):
-    ...         print(
-    ...             f"fitted with {self.n_estimators=}\\n"
-    ...             f"and {self.min_samples_split=}\\n"
-    ...             f"and {self.max_features=}"
-    ...         )
-
-    >>> class RandomForestParams(ModelParams):
-    ...     model_cls = RandomForestRegressor
-    ...     min_samples_split: int
-    ...     max_features: str
-
-    >>> params = RandomForestParams(min_samples_split=8, max_features="log2")
-    >>> params
-    RandomForestParams(min_samples_split=8, max_features='log2')
-    >>> isinstance(params, RandomForestParams)
-    True
-
-    >>> model = params.create_model()
-    >>> isinstance(model, RandomForestRegressor)
-    True
-    >>> model.fit([1, 2, 3], [4, 5, 6])
-    fitted with self.n_estimators=100
-    and self.min_samples_split=8
-    and self.max_features='log2'
-
-    :meth:`create_model` can accept additional keyword arguments, which
-    are passed to the model.
-
-    >>> params = RandomForestParams(min_samples_split=8, max_features="log2")
-
-    >>> model = params.create_model(n_estimators=500, min_samples_split=4)
-    >>> model.fit([1, 2, 3], [4, 5, 6])
-    fitted with self.n_estimators=500
-    and self.min_samples_split=4
-    and self.max_features='log2'
-
-    """  # noqa
-
-    __slots__: tuple[str, ...] = tuple()
-    model_cls: type[M] | typing.Callable[..., M]
-
-    @final
-    def create_model(self, **kwargs: Any) -> M:
+    def create_model(self, **kwargs: Any) -> Any:  # type: ignore
         """Returns a model of a type declared in ``model_cls``.
 
         The model is created with arguments collected from the params.
         Additionally, it passes arguments given directly
         to the :meth:`create_model` method.
 
-        For a class::
-
-            class RandomForestParams(ModelParams):
-                model_cls = RandomForestRegressor
-
-                min_samples_split: int
-                max_features: str
-
-            params = RandomForestParams(min_samples_split=8, max_features="log2")
-
-        calling :meth:`create_model` method::
-
-            model = params.create_model(n_estimators=500)
-
-        is equivalent to::
-
-            model = RandomForestParams(
-                min_samples_split=params.min_samples_split,
-                max_features=params.max_features,
-                n_estimators=500,
-            )
-
         Notice, that arguments passed to :meth:`create_model` have precedence
         over the arguments from ``params``.
         """
-        m = self.model_cls
+        m = type(self).model_cls  # type: ignore
         d = self.to_dict()
         d |= kwargs
         return m(**d)  # type: ignore

--- a/tests/params/test_invalid_params.py
+++ b/tests/params/test_invalid_params.py
@@ -63,14 +63,14 @@ def test_no_other_model_params_subclasses() -> None:
 
     with pytest.raises(TypeError, match="Foo"):
 
-        class InvalidParams1(letstune.ModelParams[Model], Foo):
+        class InvalidParams1(letstune.Params, Foo):
             x: int
 
         _ = InvalidParams1
 
     with pytest.raises(TypeError, match="Foo"):
 
-        class InvalidParams2(Foo, letstune.ModelParams[Model]):
+        class InvalidParams2(Foo, letstune.Params):
             x: int
 
         _ = InvalidParams2
@@ -159,7 +159,7 @@ def test_invalid_params_type() -> None:
             "__getstate__",
             "__setstate__",
         ],
-        ["letstune.Params", "letstune.ModelParams[Foo]"],
+        ["letstune.Params"],
         ["", "@classmethod"],
     ),
 )

--- a/tests/params/test_model_params.py
+++ b/tests/params/test_model_params.py
@@ -23,6 +23,8 @@ gens = [alpha_gen, beta_gen, gamma_gen]
 
 
 class MyQwertyModelParams(letstune.ModelParams[MyFooModel]):
+    model_cls = MyFooModel
+
     alpha: int = alpha_gen  # type: ignore
     beta: str = beta_gen  # type: ignore
     gamma: float = gamma_gen  # type: ignore

--- a/tests/params/test_model_params.py
+++ b/tests/params/test_model_params.py
@@ -22,7 +22,7 @@ gamma_gen = ConstantRandomParamsGenerator(3.3)
 gens = [alpha_gen, beta_gen, gamma_gen]
 
 
-class MyQwertyModelParams(letstune.ModelParams[MyFooModel]):
+class MyQwertyModelParams(letstune.Params):
     model_cls = MyFooModel
 
     alpha: int = alpha_gen  # type: ignore
@@ -41,7 +41,6 @@ def params() -> MyQwertyModelParams:
 def test_instance_creation(params: MyQwertyModelParams) -> None:
     assert isinstance(params, MyQwertyModelParams)
     assert isinstance(params, letstune.Params)
-    assert isinstance(params, letstune.ModelParams)
     assert params.alpha == 2
     assert params.beta == "qwerty"
     assert params.gamma == -10.0
@@ -166,19 +165,13 @@ def test_missing_init_keyword_argument() -> None:
         _ = MyQwertyModelParams(alpha=5, gamma=3.14)
 
 
-def test_custom_create_model_is_forbidden() -> None:
-    with pytest.raises(
-        TypeError,
-        match=re.escape(
-            """cannot override create_model. """
-            """Please use letstune.Params as the base:\n"""
-            """class MyFooParams(letstune.Params):\n"""
-            """    ...\n"""
-        ),
-    ):
+def test_custom_create_model_is_ok() -> None:
+    class MyFooParams(letstune.Params):
+        def create_model(self, x: int) -> MyFooModel:  # type: ignore
+            return MyFooModel(x=x, y=8)
 
-        class MyFooParams(letstune.ModelParams[MyFooModel]):
-            def create_model(self, x: int) -> MyFooModel:  # type: ignore
-                return MyFooModel(x=x, y=8)
+    p = MyFooParams()
+    model = p.create_model(x=5)
 
-        _ = MyFooParams
+    assert isinstance(model, MyFooModel)
+    assert model.called_kwargs == {"x": 5, "y": 8}


### PR DESCRIPTION
Closes #14

Remove `letstune.ModelParams`. Instead, use `letstune.Params` with `model_cls` parameter.